### PR TITLE
Enable building as a Python extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@
 *.kdev4
 
 build
-build_*
-3rdparty
+*.egg-info/
+__pycache__/
 
+blend2d/*.so
 src/*.c
+*.py[cd]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required( VERSION 3.1 )
 
-project( blend2d_capi C CXX )
+project( blend2d_python C CXX )
 
 # Blend2D
 # -------
@@ -19,6 +19,8 @@ endif()
 
 # Blend2D Cython Extension
 # ------------------------
+
+set( BLEND2DPY_TARGET_NAME "_capi" CACHE STRING "Name of the extension file")
 
 set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_LIST_DIR}/cmake )
 include( UseCython )

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Blend2D Python Extension
 Dependencies
 ------------
 
-* Blend2D and AsmJit sources
 * Numpy
+* Blend2D and AsmJit sources (build-time only)
 * Cython (build-time only)
 * CMake (build-time only)

--- a/blend2d/__init__.py
+++ b/blend2d/__init__.py
@@ -1,0 +1,28 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2019 John Wiggins
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import absolute_import
+
+from ._capi import (
+    Array, ArrayType, Context, ExtendMode, Format, Gradient, GradientType,
+    Image, Matrix2D, Path, Pattern, Rect, RectI, Region,
+)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,29 @@
+# Documentation for the contents of this file can be found here:
+# http://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
+
+[metadata]
+name = blend2d
+version = 0.0.1
+description = Blend2D Python Bindings
+url = https://github.com/jwiggins/blend2d-python
+author = John Wiggins
+license = MIT
+classifiers =
+    Development Status :: 4 - Beta
+    Environment :: Console
+    Intended Audience :: Developers
+    License :: OSI Approved :: MIT License
+    Programming Language :: C++
+    Programming Language :: Cython
+    Programming Language :: Python
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 3
+    Topic :: Software Development :: Libraries
+    Operating System :: Microsoft :: Windows
+    Operating System :: POSIX
+    Operating System :: Unix
+    Operating System :: MacOS
+
+[options]
+zip_safe = False
+packages = find:

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,75 @@
+import os
+import os.path as op
+import platform
+import subprocess
+import sys
+
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext
+
+# Set to 'Release' when building a release
+BUILD_TYPE = 'Debug'
+
+
+class CMakeExtension(Extension):
+    def __init__(self, name, cmake_lists_dir='.', sources=None, **kwa):
+        sources = [] if sources is None else sources
+        Extension.__init__(self, name, sources=sources, **kwa)
+        self.cmake_lists_dir = os.path.abspath(cmake_lists_dir)
+
+
+class cmake_build_ext(build_ext):
+    def build_extensions(self):
+        try:
+            subprocess.check_output(['cmake', '--version'])
+        except OSError:
+            raise RuntimeError('Cannot find CMake executable')
+
+        for ext in self.extensions:
+            extpath = self.get_ext_fullpath(ext.name)
+            extdir = op.abspath(op.dirname(extpath))
+            extfile = op.splitext(op.basename(extpath))[0]
+            tmpdir = self.build_temp
+            cmake_args = [
+                '-DBLEND2DPY_TARGET_NAME={}'.format(extfile),
+                '-DCMAKE_BUILD_TYPE={}'.format(BUILD_TYPE),
+                '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(
+                    BUILD_TYPE.upper(), extdir),
+                '-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_{}={}'.format(
+                    BUILD_TYPE.upper(), extdir),
+                '-DPYTHON_EXECUTABLE={}'.format(sys.executable),
+            ]
+
+            if platform.system() == 'Windows':
+                plat = ('x64' if platform.architecture()[0] == '64bit'
+                        else 'Win32')
+                cmake_args += [
+                    '-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE',
+                    '-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_{}={}'.format(
+                        BUILD_TYPE.upper(), extdir),
+                ]
+                if self.compiler.compiler_type == 'msvc':
+                    cmake_args += [
+                        '-DCMAKE_GENERATOR_PLATFORM={}'.format(plat),
+                    ]
+                else:
+                    cmake_args += [
+                        '-G', 'MinGW Makefiles',
+                    ]
+
+            if not op.exists(tmpdir):
+                os.makedirs(tmpdir)
+
+            # Config and build the extension
+            cmd = ['cmake', ext.cmake_lists_dir] + cmake_args
+            subprocess.check_call(cmd, cwd=tmpdir)
+            cmd = ['cmake', '--build', '.', '--config', BUILD_TYPE]
+            subprocess.check_call(cmd, cwd=tmpdir)
+
+
+if __name__ == '__main__':
+    # See setup.cfg for package metadata
+    setup(
+        ext_modules=[CMakeExtension('blend2d._capi')],
+        cmdclass={'build_ext': cmake_build_ext},
+    )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,5 +12,11 @@ endif()
 include_directories( ${NUMPY_INCLUDE_DIR} )
 
 cython_add_module( _capi _capi.pyx )
+set_target_properties( _capi PROPERTIES OUTPUT_NAME ${BLEND2DPY_TARGET_NAME} )
+
+if(WIN32)
+    set_target_properties( _capi PROPERTIES SUFFIX ".pyd" )
+endif()
+
 target_include_directories( _capi BEFORE PRIVATE ${BLEND2D_INCLUDE_DIR} )
 target_link_libraries( _capi ${BLEND2D_LIBS} )


### PR DESCRIPTION
Added a `setup.py` script so that the extension can be installed easily into the python environment of your choosing.