### PR TITLE
Make the API more like the blend2d C++ API

### DIFF
--- a/examples/gradient.py
+++ b/examples/gradient.py
@@ -13,14 +13,14 @@ if __name__ == '__main__':
     gradient.add_stop(0.5, (1.0, 0.69, 0.0))
     gradient.add_stop(1.0, (1.0, 0.0, 0.0))
 
-    context.set_fill_gradient(gradient)
-    context.fill()
+    context.set_fill_style(gradient)
+    context.fill_all()
 
     circle = blend2d.Path()
     circle.ellipse(128, 128, 64, 64)
 
     context.set_comp_op(blend2d.CompOp.EXCLUSION)
-    context.set_fill_color((0.0, 1.0, 1.0))
-    context.draw_path(circle)
+    context.set_fill_style((0.0, 1.0, 1.0))
+    context.fill_path(circle)
 
     imsave('gradient.png', array)

--- a/examples/pattern.py
+++ b/examples/pattern.py
@@ -1,0 +1,46 @@
+import blend2d
+import numpy as np
+from skimage.io import imsave
+
+
+def random_lines(context, width, height):
+    xs = np.random.randint(0, high=width, size=(100, 2))
+    ys = np.random.randint(0, high=height, size=(100, 2))
+    colors = np.random.random_sample(size=(100, 3))
+
+    context.set_fill_style((1.0, 1.0, 1.0))
+    context.fill_all()
+
+    path = blend2d.Path()
+    for (x0, x1), (y0, y1), color in zip(xs, ys, colors):
+        context.set_stroke_style(color)
+        path.reset()
+        path.move_to(x0, y0)
+        path.line_to(x1, y1)
+        context.stroke_path(path)
+
+
+if __name__ == '__main__':
+    pattern_image = blend2d.Image(np.empty((256, 256, 4), dtype=np.uint8))
+    pattern_context = blend2d.Context(pattern_image)
+    random_lines(pattern_context, 256, 256)
+
+    array = np.empty((512, 512, 4), dtype=np.uint8)
+    image = blend2d.Image(array)
+    context = blend2d.Context(image)
+    context.clear()
+
+    area = blend2d.RectI(0, 0, 256, 256)
+    matrix = blend2d.Matrix2D()
+    matrix.rotate(128.0, 128.0, 45.0)
+    matrix.scale(0.25, 0.25)
+    pattern = blend2d.Pattern(
+        pattern_image, area, blend2d.ExtendMode.REPEAT, matrix
+    )
+    context.set_fill_style(pattern)
+
+    circle = blend2d.Path()
+    circle.ellipse(256, 256, 200, 200)
+    context.fill_path(circle)
+
+    imsave('pattern.png', array)

--- a/examples/spiral.py
+++ b/examples/spiral.py
@@ -47,8 +47,7 @@ def spiral(size, hue, sat, val):
 
     canvas.clear()  # fill with black
     for idx, offset in enumerate(offsets):
-        canvas.set_fill_color(spectrum[idx])
-        canvas.set_stroke_color(spectrum[idx])
+        canvas.set_fill_style(spectrum[idx])
         radius = np.pi * offset / CIRCLE_COUNT
         scale = radius / CIRCLE_SIZE
         for i in range(CIRCLE_COUNT):
@@ -58,7 +57,7 @@ def spiral(size, hue, sat, val):
             canvas.translate(size[0]/2 + offset*centers[i, 0],
                              size[1]/2 + offset*centers[i, 1])
             canvas.scale(scale, scale)
-            canvas.draw_path(circle)
+            canvas.fill_path(circle)
 
     # BGRA -> RGBA
     array[:, :, [0, 1, 2]] = array[:, :, [2, 1, 0]]

--- a/examples/text.py
+++ b/examples/text.py
@@ -8,10 +8,10 @@ if __name__ == '__main__':
     canvas = blend2d.Context(image)
 
     canvas.clear()
-    canvas.set_fill_color((1.0, 1.0, 1.0))
+    canvas.set_fill_style((1.0, 1.0, 1.0))
 
     text = u'Hello World!'
     font = blend2d.Font('/Library/Fonts/Skia.ttf', 50)
-    canvas.draw_text((100, 100), font, text)
+    canvas.fill_text((100, 100), font, text)
 
     imsave('text.png', array)

--- a/src/geometry.pxi
+++ b/src/geometry.pxi
@@ -67,14 +67,24 @@ cdef class Matrix2D:
     def __cinit__(self):
         _capi.blMatrix2DSetIdentity(&self._self)
 
-    def rotate(self, double cx, double cy, double angle):
-        _capi.blMatrix2DSetRotation(&self._self, angle, cx, cy)
+    def rotate(self, double angle, double cx, double cy):
+        cdef double data[3]
+        data[0] = angle
+        data[1] = cx
+        data[2] = cy
+        _capi.blMatrix2DApplyOp(&self._self, _capi.BLMatrix2DOp.BL_MATRIX2D_OP_ROTATE_PT, data)
 
     def scale(self, double x, double y):
-        _capi.blMatrix2DSetScaling(&self._self, x, y)
+        cdef double data[2]
+        data[0] = x
+        data[1] = y
+        _capi.blMatrix2DApplyOp(&self._self, _capi.BLMatrix2DOp.BL_MATRIX2D_OP_SCALE, data)
 
     def translate(self, double x, double y):
-        _capi.blMatrix2DSetTranslation(&self._self, x, y)
+        cdef double data[2]
+        data[0] = x
+        data[1] = y
+        _capi.blMatrix2DApplyOp(&self._self, _capi.BLMatrix2DOp.BL_MATRIX2D_OP_TRANSLATE, data)
 
 
 cdef class Rect:


### PR DESCRIPTION
This PR makes several changes to better match the C++ API:
* Instead of `set_[fill|stroke]_[color|gradient]` methods on `Context`, there are now just `set_fill_style` and `set_stroke_style` which both take either a `Gradient`, `Pattern` or iterable (tuple, list, numpy array) which represents an RGB[A] color.
  * This also means that `Pattern` fills are possible now. An example has been added.
* Instead of `draw_[rect|path|text]` methods on `Context`, there are now `fill_*` and `stroke_*` methods.
* `Context.fill` has been renamed to `Context.fill_all`
* The `Matrix2D` has been fixed so that it can actually accumulate successive operations.